### PR TITLE
Add --source-encoding argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ Optional prefix for `INCLUDE_ASM` files.
 ### `--macro-inc-path`
 Optional path to your `macro.inc` file.
 
+### `--source-encoding`
+Optional encoding to re-encode C sources with before compilation.
+
 All additional arguments will be passed to the MWCC executable.
 
 

--- a/mwccgap.py
+++ b/mwccgap.py
@@ -34,7 +34,7 @@ def main() -> None:
     parser.add_argument(
         "--source-encoding",
         type=str,
-        help="The encoding to re-encode C sources with before compilation."
+        help="Optional encoding to re-encode C sources with before compilation."
     )
 
     args, c_flags = parser.parse_known_args()

--- a/mwccgap.py
+++ b/mwccgap.py
@@ -31,6 +31,12 @@ def main() -> None:
     parser.add_argument("--asm-dir-prefix", type=Path)
     parser.add_argument("--macro-inc-path", type=Path)
 
+    parser.add_argument(
+        "--source-encoding",
+        type=str,
+        help="The encoding to re-encode C sources with before compilation."
+    )
+
     args, c_flags = parser.parse_known_args()
 
     as_flags = ["-G0"]  # TODO: base this on -sdatathreshold value from c_flags
@@ -56,6 +62,7 @@ def main() -> None:
                 as_flags=as_flags,
                 asm_dir_prefix=args.asm_dir_prefix,
                 macro_inc_path=args.macro_inc_path,
+                source_encoding=args.source_encoding,
             )
 
     except Exception as e:

--- a/mwccgap/mwccgap.py
+++ b/mwccgap/mwccgap.py
@@ -250,12 +250,13 @@ def compile_file(
     with tempfile.TemporaryDirectory() as temp_dir:
         o_file = Path(temp_dir) / "result.o"
 
-        if source_encoding is not None:
-            encoded_c_file = Path(temp_dir) / "encoded_source.c"
+        if source_encoding != None:
+            encoded_c_file = tempfile.NamedTemporaryFile(suffix=".c", dir=c_file.parent)
+            encoded_c_file_path = Path(encoded_c_file.name)
             source_text = c_file.read_text()
             encoded_source_text = source_text.encode(source_encoding)
-            encoded_c_file.write_bytes(encoded_source_text)
-            c_file = encoded_c_file
+            encoded_c_file_path.write_bytes(encoded_source_text)
+            c_file = encoded_c_file_path
 
         stdout, stderr = compile_file_helper(
             c_file,

--- a/mwccgap/mwccgap.py
+++ b/mwccgap/mwccgap.py
@@ -250,7 +250,7 @@ def compile_file(
     with tempfile.TemporaryDirectory() as temp_dir:
         o_file = Path(temp_dir) / "result.o"
 
-        if source_encoding != None:
+        if source_encoding is not None:
             encoded_c_file = tempfile.NamedTemporaryFile(suffix=".c", dir=c_file.parent)
             encoded_c_file_path = Path(encoded_c_file.name)
             source_text = c_file.read_text()

--- a/mwccgap/mwccgap.py
+++ b/mwccgap/mwccgap.py
@@ -250,7 +250,7 @@ def compile_file(
     with tempfile.TemporaryDirectory() as temp_dir:
         o_file = Path(temp_dir) / "result.o"
 
-        if source_encoding != None:
+        if source_encoding is not None:
             encoded_c_file = Path(temp_dir) / "encoded_source.c"
             source_text = c_file.read_text()
             encoded_source_text = source_text.encode(source_encoding)

--- a/mwccgap/mwccgap.py
+++ b/mwccgap/mwccgap.py
@@ -156,26 +156,13 @@ def preprocess_s_file(
     return (c_lines, rodata_entries)
 
 
-def read_c_file_lines(
-    c_file,
-    expected_encodings: List[str]
-) -> Tuple[List[str], str]:
-    for encoding in expected_encodings:
-        try:
-            with open(c_file, "r", encoding=encoding) as f:
-                return (f.readlines(), encoding)
-        except:
-            pass
-
-    raise RuntimeError(f"Failed to open {c_file} with any of the expected encodings ({expected_encodings})")
-
-
 def preprocess_c_file(
     c_file,
     asm_dir_prefix: Optional[Path] = None,
-    expected_encodings: List[str] = ["utf", "shift_jis"],
-) -> Tuple[List[str], List[Tuple[Path, int]], str]:
-    lines, encoding = read_c_file_lines(c_file, expected_encodings)
+) -> Tuple[List[str], List[Tuple[Path, int]]]:
+    with open(c_file, "r") as f:
+        lines = f.readlines()
+    
     out_lines: List[str] = []
     asm_files: List[Tuple[Path, int]] = []
     for i, line in enumerate(lines):
@@ -217,7 +204,7 @@ def preprocess_c_file(
         else:
             out_lines.append(line)
 
-    return (out_lines, asm_files, encoding)
+    return (out_lines, asm_files)
 
 
 def compile_file_helper(
@@ -304,7 +291,7 @@ def process_c_file(
     precompiled_elf = Elf(obj_bytes)
 
     # 2. identify all INCLUDE_ASM statements and replace with asm statements full of nops
-    out_lines, asm_files, encoding = preprocess_c_file(c_file, asm_dir_prefix=asm_dir_prefix)
+    out_lines, asm_files = preprocess_c_file(c_file, asm_dir_prefix=asm_dir_prefix)
 
     # for now we only care about the names of the functions that exist
     c_functions = [f.function_name for f in precompiled_elf.get_functions()]
@@ -321,7 +308,7 @@ def process_c_file(
 
     # 3. compile the modified .c file for real
     with tempfile.NamedTemporaryFile(suffix=".c", dir=c_file.parent) as temp_c_file:
-        temp_c_file.write("\n".join(out_lines).encode(encoding))
+        temp_c_file.write("\n".join(out_lines).encode("utf"))
         temp_c_file.flush()
 
         obj_bytes = compile_file(


### PR DESCRIPTION
Added the ability to re-encode C sources with the desired encoding before compilation. This is gonna allow projects with unconventional source file encodings (like Shift JIS, EUC-JP, etc.) to store sources as UTF-8 while compiling them as the target encoding.