### PR TITLE
Add Support for -MD, -MMD, -gccdep

### DIFF
--- a/mwccgap/makerule.py
+++ b/mwccgap/makerule.py
@@ -1,0 +1,70 @@
+from pathlib import Path
+import re
+
+
+class MakeRule:
+    target: str
+    source: str | None
+    includes: list[str]
+
+    def __init__(self, data: bytes, use_wibo=False):
+        if use_wibo:
+            encoding = "iso-8859-1"
+        else:
+            encoding = "utf-8"
+
+        rule = data.decode(encoding)
+        rule = re.sub(r"\\[\r\n]+", " ", rule)
+        (target, remaining) = re.split(": ", rule)
+        files = remaining.split()
+        files.insert(0, target)
+
+        if use_wibo:
+            files = [path_from_wibo(p) for p in files]
+
+        # the first file is the target, the second is the
+        self.target = files.pop(0)
+        self.source = files.pop(0)
+        self.includes = files
+
+    def as_str(self):
+        rule = f"{self.target}: "
+        if self.source is not None:
+            rule += f"{self.source} "
+        for file in self.includes:
+            rule += f"\\\n\t{file} "
+        rule += "\n"
+
+        return rule
+
+
+# an implementation of the wibo translation from "windows"
+# path to a unix path
+def path_from_wibo(path_str: str) -> Path:
+    path_str = path_str.replace("\\", "/")
+
+    # remove the extended path prefix
+    if path_str.startswith("//?/"):
+        path_str = path_str[4:]
+
+    # remove the drive letter
+    if path_str.lower().startswith("z:/"):
+        path_str = path_str[2:]
+
+    # if it exists, we're done
+    path = Path(path_str)
+    if path.is_file():
+        return path
+
+    # otherwise try to find a case insensitive match
+    new_path = Path(".")
+    for part in path.parts:
+        candidate = new_path / part
+        if new_path.is_dir():
+            for entry in new_path.iterdir():
+                if entry.name.lower() == part.lower():
+                    candidate = new_path / entry.name
+                    break
+        new_path = candidate
+
+    return new_path

--- a/tests/test_deps.py
+++ b/tests/test_deps.py
@@ -1,0 +1,140 @@
+import tempfile
+import unittest
+import os
+import re
+import shutil
+
+from pathlib import Path
+from mwccgap.compiler import Compiler
+from mwccgap.makerule import MakeRule
+
+mwcc = os.getenv("MWCC")
+if mwcc is None:
+    mwcc = "mwccpsp.exe"
+
+
+def has_wibo_and_mwcc():
+    wibo = shutil.which("wibo")
+    mwcc_exe = shutil.which(mwcc)
+    return wibo is not None and mwcc_exe is not None
+
+
+class TestDependencies(unittest.TestCase):
+    def __init__(self, x):
+        super().__init__(x)
+        self.wibo = shutil.which("wibo")
+        self.mwcc = shutil.which(mwcc)
+
+    def has_dependencies(self):
+        return self.wibo is not None and self.mwcc is not None
+
+    def _compile(self, c_flags: list[str], program: str):
+        compiler = Compiler(c_flags, self.mwcc, True, self.wibo)
+
+        test_path = os.path.abspath(__file__)
+        test_dir = os.path.dirname(test_path)
+        with tempfile.NamedTemporaryFile(suffix=".c", dir=test_dir) as c_file:
+            c_file.write(program.encode("utf-8"))
+            c_file.flush()
+            compiler.compile_file(Path(c_file.name))
+
+        return compiler
+
+    @unittest.skipUnless(has_wibo_and_mwcc(), "requires wibo and mwcc")
+    def test_dependencies_gcc_behavior(self):
+        compiler = self._compile(
+            ["-MD", "-gccdep"],
+            """
+int add(int a, int b) {
+    return a + b;
+}
+""",
+        )
+
+        rule = compiler.make_rule
+
+        self.assertTrue(
+            str(rule.target).startswith("/tmp"),
+            f"target: {rule.target} should start with /tmp",
+        )
+        self.assertTrue(
+            str(rule.target).endswith("result.o"),
+            f"target: {rule.target} should end with result.o",
+        )
+        self.assertTrue(str(rule.source).endswith(".c"))
+        self.assertEqual(0, len(rule.includes))
+
+    @unittest.skipUnless(has_wibo_and_mwcc(), "requires wibo and mwcc")
+    def test_no_dependencies_mw_behavior(self):
+        compiler = self._compile(
+            ["-MD"],
+            """int add(int a, int b) {
+    return a + b;
+}
+""",
+        )
+
+        rule = compiler.make_rule
+
+        self.assertTrue(
+            str(rule.target).startswith("/tmp"),
+            f"target: {rule.target} should start with /tmp",
+        )
+        self.assertTrue(
+            str(rule.target).endswith("result.o"),
+            f"target: {rule.target} should end with result.o",
+        )
+        self.assertTrue(str(rule.source).endswith(".c"))
+        self.assertEqual(0, len(rule.includes))
+
+    @unittest.skipUnless(has_wibo_and_mwcc(), "requires wibo and mwcc")
+    def test_no_depencies(self):
+        compiler = self._compile(
+            [],
+            """int add(int a, int b) {
+    return a + b;
+}
+""",
+        )
+
+        rule = compiler.make_rule
+
+        self.assertIsNone(rule)
+
+    def test_make_rule_simple(self):
+        wibo_make_rule = "Z:\\tmp\\tmpfmuzt8mz\\result.o: test.c \r\n".encode("ascii")
+
+        rule = MakeRule(wibo_make_rule, True)
+
+        self.assertEqual(Path("/tmp/tmpfmuzt8mz/result.o"), rule.target)
+        self.assertEqual(Path("test.c"), rule.source)
+        self.assertEqual([], rule.includes)
+        self.assertEqual("/tmp/tmpfmuzt8mz/result.o: test.c \n", rule.as_str())
+
+    def test_make_rule_with_includes(self):
+        wibo_make_rule = (
+            "Z:\\tmp\\tmpfkcxmvnu\\result.o: test2.c \\\r\n"
+            "\tZ:\\home\\user\\Projects\\mwccgap\\decl.h \\\r\n"
+            "\t\\\\?\\Z:\\home\\user\\Projects\\mwccgap\\lib.h \r\n"
+        ).encode("ascii")
+
+        rule = MakeRule(wibo_make_rule, True)
+
+        expected_rule = (
+            "/tmp/tmpfkcxmvnu/result.o: test2.c \\\n"
+            "\t/home/user/Projects/mwccgap/decl.h \\\n"
+            "\t/home/user/Projects/mwccgap/lib.h \n"
+        )
+        self.assertEqual(expected_rule, rule.as_str())
+
+    def test_unix_deps(self):
+        make_rule = (
+            "/tmp/tmpfkcxmvnu/result.o: test.c \\\n" "\tdecl.h \\\n" "\tlib.h \n"
+        ).encode("utf-8")
+
+        rule = MakeRule(make_rule, False)
+
+        self.assertEqual("/tmp/tmpfkcxmvnu/result.o", rule.target)
+        self.assertEqual("test.c", rule.source)
+        self.assertEqual(["decl.h", "lib.h"], rule.includes)
+        self.assertEqual(make_rule.decode("utf-8"), rule.as_str())


### PR DESCRIPTION
Makes `Compiler` aware of any dependency file that `mwccpsp.exe` might emit and if run through `wibo`, it converts the paths from DOS to Unix paths. This allows tools like `make` or `ninja` to rebuild objects based on the source file's embedded dependencies ensuring that files get rebuilt when necessary and avoiding rebuilding files when not needed.

`mwccpsp.exe` supports two modes when emitting dependency files in addition to a compiled output - gcc compatibility mode (specified by the `-gccdep` argument) where the file is placed next to the output object, and another where the file is placed in `$PWD`. Both modes are supported, but MetroWorks mode only works with a regular file input (and not stdin).

In cases where the input C file is read from stdin, the source dependency for the make rule cannot be determined. Instead of using the ephemeral C file, the dependency is removed from the output rule.

In all cases the include headers that are emitted are absoluate paths, unlike GCC. Additional post-processing could be done to determine if the absolute path matches one of the relative include paths, but that is not necessary for the current use case.

`-M` and `-MM` options are not supported because they change the primary output of `mwccpsp.exe` and later logic assumes its processing an ELF file. This case could be detected as well, but is not currently needed.