### PR TITLE
Ignore `nonmatching` marker

### DIFF
--- a/mwccgap/preprocessor.py
+++ b/mwccgap/preprocessor.py
@@ -131,7 +131,7 @@ class Preprocessor:
             if line.startswith("endlabel") or line.startswith("enddlabel"):
                 # ignore function / symbol ends
                 continue
-            if line.startswith("nmlabel"):
+            if line.startswith("nonmatching"):
                 # ignore non matching marker
                 continue
             if line.startswith(".L") and line.endswith(":"):


### PR DESCRIPTION
The marker introduced in #26 was renamed from `nmlabel` to `nonmatching` yesterday in https://github.com/ethteck/splat/pull/466, after #26 was already merged.
This PR updates to the corresponding new name.

