### PR TITLE
Set language linkage to "C" when compiling C++

### DIFF
--- a/mwccgap/constants.py
+++ b/mwccgap/constants.py
@@ -16,3 +16,15 @@ SYMBOL_SINIT = "__sinit_"
 LOCAL_SUFFIX = ", local"
 
 IGNORED_RELOCATIONS = (".rel.pdr",)
+
+BEFORE_PREPROCESSED_LINES = """
+#ifdef __cplusplus
+extern "C" {
+#endif
+""".splitlines()
+
+AFTER_PREPROCESSED_LINES = """
+#ifdef __cplusplus
+}
+#endif
+""".splitlines()

--- a/mwccgap/constants.py
+++ b/mwccgap/constants.py
@@ -16,15 +16,3 @@ SYMBOL_SINIT = "__sinit_"
 LOCAL_SUFFIX = ", local"
 
 IGNORED_RELOCATIONS = (".rel.pdr",)
-
-BEFORE_PREPROCESSED_LINES = """
-#ifdef __cplusplus
-extern "C" {
-#endif
-""".splitlines()
-
-AFTER_PREPROCESSED_LINES = """
-#ifdef __cplusplus
-}
-#endif
-""".splitlines()

--- a/mwccgap/preprocessor.py
+++ b/mwccgap/preprocessor.py
@@ -16,9 +16,20 @@ from .constants import (
     INCLUDE_RODATA_REGEX,
     BLOCK_COMMENT_REGEX,
     LOCAL_SUFFIX,
-    BEFORE_PREPROCESSED_LINES,
-    AFTER_PREPROCESSED_LINES,
 )
+
+
+C_MACRO_START = """
+#ifdef __cplusplus
+extern "C" {
+#endif
+""".splitlines()
+
+C_MACRO_END = """
+#ifdef __cplusplus
+}
+#endif
+""".splitlines()
 
 
 @dataclass
@@ -233,9 +244,9 @@ class Preprocessor:
                     raise Exception(f"Failed to preprocess {asm_file}: {e}") from None
 
                 asm_files.append((asm_file, len(rodata_entries)))
-                out_lines += BEFORE_PREPROCESSED_LINES
+                out_lines += C_MACRO_START
                 out_lines += new_lines
-                out_lines += AFTER_PREPROCESSED_LINES
+                out_lines += C_MACRO_END
             else:
                 out_lines.append(line)
 

--- a/mwccgap/preprocessor.py
+++ b/mwccgap/preprocessor.py
@@ -16,6 +16,8 @@ from .constants import (
     INCLUDE_RODATA_REGEX,
     BLOCK_COMMENT_REGEX,
     LOCAL_SUFFIX,
+    BEFORE_PREPROCESSED_LINES,
+    AFTER_PREPROCESSED_LINES,
 )
 
 
@@ -231,7 +233,9 @@ class Preprocessor:
                     raise Exception(f"Failed to preprocess {asm_file}: {e}") from None
 
                 asm_files.append((asm_file, len(rodata_entries)))
+                out_lines += BEFORE_PREPROCESSED_LINES
                 out_lines += new_lines
+                out_lines += AFTER_PREPROCESSED_LINES
             else:
                 out_lines.append(line)
 


### PR DESCRIPTION
Using `mwccgap` as-is within a C++ project fails with the following signature:
```
Exception processing lighting.cpp: func_08860760 not found in src/lighting.cpp
Traceback (most recent call last):
  File "./tools/mwccgap/mwccgap.py", line 64, in main
    process_c_file(
  File "./tools/mwccgap/mwccgap/mwccgap.py", line 128, in process_c_file
    raise Exception(f"{function} not found in {c_file}")
Exception: func_08860760 not found in src/lighting.cpp
```

Wrapping every `INCLUDE_*()` statement with `extern "C"` works around this issue, but adds friction to the workflow.

This change adds the typical `#ifdef __cplusplus`-guarded language linkage statements to the preprocessed c output.