### PR TITLE
fix alignment calculation from `sh_addralign`

### DIFF
--- a/mwccgap/elf.py
+++ b/mwccgap/elf.py
@@ -271,7 +271,7 @@ class Elf:
 
             sh_offset += len(data)
 
-            alignment = 1 << section.sh_addralign
+            alignment = section.sh_addralign
             if alignment:
                 if sh_offset % alignment:
                     bytes_needed = alignment - (sh_offset % alignment)


### PR DESCRIPTION
hi hi! found this today. per https://man7.org/linux/man-pages/man5/elf.5.html, `sh_addralign` is a power of two or zero, rather than the exponent (log2) of the alignment value

let me know if we need to add a test for this
